### PR TITLE
Fix: Skip showing terminal if buffer is no longer valid or not exists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fix: Correctly center floating terminal when no borders are used.
+- Fix: Skip showing terminal if buffer is no longer valid or it doesn't exist.
 - Set terminal window as `nolist`.
 - Add `fixed_height` & `fixed_width` options to control whether terminal size should be preserved on new splits.
 - Do not ignore wildcard patterns when expanding `dir`.

--- a/lua/ergoterm/instance/open.lua
+++ b/lua/ergoterm/instance/open.lua
@@ -34,7 +34,7 @@ end
 ---@param term Terminal
 ---@param layout layout?
 function M.show(term, layout)
-  if not M.is_open(term) then
+  if not M.is_open(term) and term._state.bufnr and vim.api.nvim_buf_is_valid(term._state.bufnr) then
     layout = layout or term._state.layout
     local window = nil
     if vim.tbl_contains(NEW_WINDOW_LAYOUTS, layout) then

--- a/spec/ergoterm/instance/open_spec.lua
+++ b/spec/ergoterm/instance/open_spec.lua
@@ -112,6 +112,18 @@ describe(".open", function()
     assert.equal("right", win_config.split)
   end)
 
+  it("does nothing if buffer is missing", function()
+    local term = Terminal:new():start()
+    term:cleanup()
+
+    local ok = pcall(function()
+      open.show(term)
+    end)
+
+    assert.is_true(ok)
+    assert.is_nil(term:get_state("window"))
+  end)
+
   it("errors if layout is invalid", function()
     local term = Terminal:new()
 


### PR DESCRIPTION
Closes #28
